### PR TITLE
push also versioned image (!= latest) to hub.docker.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,8 @@ deploy:
     script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin ; docker push sogis/ccc-service:latest
     on:
       branch: master
+  - provider: script
+    skip_cleanup: true
+    script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin ; docker push sogis/ccc-service:$TRAVIS_BUILD_NUMBER
+    on:
+      branch: master


### PR DESCRIPTION
Stünde das go-live nicht vor der Türe, hätte ich es gemerged.

Was man sich noch überlegen kann: Will man eher 1.0.$TRAVIS_BUILD_NUMBER? Bei API-Breaks gäbe es dann 2.0.$TRAVIS_BUILD_NUMBER