### PR TITLE
disconnect message for intentional V1.2 session termination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up JDK 25
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 25
         distribution: temurin
@@ -42,7 +42,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up JDK 25
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 25
         distribution: temurin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [ master, umweltplus_fix ]
+    branches: [ master ]
     paths-ignore:
       - '**/*.md'
   pull_request:
-    branches: [ master, umweltplus_fix ]
+    branches: [ master ]
     paths-ignore:
       - '**/*.md'
   workflow_call:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Details: [Spezifikation V1.0 (PDF)](docs/res/Spezifikation_CCC_Schnittstelle_V1.
 |---|---|---|---|
 |changeLayerVisibility|F > K|RUN|Aufforderung an die Kartenapplikation, eine geladene Ebene auf sichtbar/unsichtbar zu schalten.|
 |reconnectGis / reconnectApp|F,K > CCC|RUN|Anfrage eines V1.2-Clients, nach einem Verbindungsunterbruch wieder in die bestehende Session aufgenommen zu werden.|
+|disconnectGis / disconnectApp|F,K > CCC|RUN|Signalisiert dem Server, dass der V1.2-Client die Session absichtlich beendet. Sofortige Terminierung ohne Reconnect-Grace-Period.|
 |keyChange|CCC > F,K|RUN|Aufforderung des Servers an einen V1.2-Client, die Keys auszutauschen.|
 
 `notifySessionReady` wird mit V1.2 um `connectionKey` und `sessionNr` erweitert.

--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,18 @@ tasks.register('smokeTest', Test) {
     useJUnitPlatform {
         includeTags 'smoke'
     }
-    if (findProperty('ccc.smoke.url')) {
-        systemProperty 'ccc.smoke.url', findProperty('ccc.smoke.url')
+    def smokeUrl = System.getProperty('ccc.smoke.url') ?: findProperty('ccc.smoke.url')
+    if (smokeUrl) {
+        systemProperty 'ccc.smoke.url', smokeUrl
+        doFirst { logger.lifecycle("Smoke test URL: {}", smokeUrl) }
+    } else {
+        def propsFile = file('src/main/resources/application.properties')
+        doFirst {
+            def props = new Properties()
+            propsFile.withInputStream { props.load(it) }
+            def fallback = props.getProperty('ccc.smoke.url')
+            logger.lifecycle("Smoke test URL (from application.properties): {}", fallback)
+        }
     }
 }
 

--- a/docs/dev/architektur.md
+++ b/docs/dev/architektur.md
@@ -284,6 +284,10 @@ Stale-Session Erkennung (SessionsGroomer):
   V1.0-Sessions: Sofort stale wenn eine Verbindung geschlossen wird
   V1.2-Sessions: Erst stale nach 1 Minute Grace Period (Reconnect-Fenster)
 
+  CloseStatus beim Entfernen:
+    Handshake-Timeout:    GOING_AWAY (1001), "Handshake timeout exceeded"
+    Reconnection-Timeout: NORMAL (1000), "Reconnection timeout"
+
 Zeitlicher Ablauf (Beispieltag):
   00:00 ─── Groomer laueft alle 5 Min., Ping alle 30 Sek., KeyChanger alle 5 Min. ───
   03:00 ─── SessionsKiller: alle Sessions gekillt, Zaehler -> 0
@@ -410,7 +414,7 @@ Limits:
 Ablauf:
   afterConnectionEstablished()
     -> ConnectionLimiter.isConnectionAllowed(ip)
-       -> Falls ueberschritten: Session sofort schliessen (POLICY_VIOLATION)
+       -> Falls ueberschritten: Session sofort schliessen (SERVICE_OVERLOAD)
     -> ConnectionLimiter.recordConnectionOpened(ip)
 
   afterConnectionClosed()

--- a/docs/dev/readme.md
+++ b/docs/dev/readme.md
@@ -62,7 +62,7 @@ Smoke Tests prüfen einen bereits deployten CCC-Service. Sie sind mit dem JUnit-
 und werden mit dem Gradle-Task `smokeTest` ausgeführt:
 
 ```bash
-./gradlew smokeTest -Pccc.smoke.url=https://<host>/ccc
+./gradlew smokeTest -Pccc.smoke.url=wss://<host>/ccc-service
 ```
 
 Die Property `ccc.smoke.url` gibt die Basis-URL des zu testenden Service an.

--- a/docs/protocol/v1.2.md
+++ b/docs/protocol/v1.2.md
@@ -141,7 +141,7 @@ Bei einem regulären Beenden der Fachapplikation oder des Web GIS Clients soll d
 Die `disconnect`-Nachricht wird nur von V1.2-Verbindungen akzeptiert. V1.0-Verbindungen werden beim Schliessen ohnehin sofort terminiert und benötigen diese Nachricht nicht. Sendet ein V1.0-Client eine `disconnect`-Nachricht, wird sie mit einem Fehler abgelehnt.
 
 Nach Empfang einer `disconnect`-Nachricht von einem V1.2-Client:
-1. Beide Verbindungen (App und GIS) werden mit Close-Code `1000 NORMAL` und Reason `"Client disconnected"` geschlossen.
+1. Beide Verbindungen (App und GIS) werden mit Close-Code `1000 NORMAL` und Reason `"Peer connection closed (V1.2)"` geschlossen.
 2. Die Session wird sofort aus der Session-Verwaltung entfernt.
 3. Ein Reconnect auf diese Session ist danach nicht mehr möglich.
 

--- a/docs/protocol/v1.2.md
+++ b/docs/protocol/v1.2.md
@@ -6,6 +6,7 @@
 |---|---|---|---|
 |changeLayerVisibility|F > K|RUN|Aufforderung an die Kartenapplikation, eine geladene Ebene auf sichtbar/unsichtbar zu schalten.|
 |reconnectGis & reconnectApp|F,K > CCC|RUN|Anfrage eines V1.2-Clients, nach einem Verbindungsunterbruch wieder in die bestehende Session aufgenommen zu werden.|
+|disconnectGis & disconnectApp|F,K > CCC|RUN|Signalisiert dem Server, dass der Client die Session absichtlich beendet. Die Session wird sofort geschlossen, ohne Reconnect-Grace-Period.|
 |keyChange|CCC > F,K|RUN|Aufforderung des Servers an einen V1.2-Client, die Keys auszutauschen.|
 
 ## Erweiterte Nachrichten aufgrund der Reconnects
@@ -120,6 +121,37 @@ Der CCC-Server führt neu für jede Session vier Informationen:
 ```
 
 Falls das reconnect vom CCC-Server akzeptiert wird, sendet dieser in der Folge eine keyChange-Anforderung an den Client.
+
+## disconnectGis / disconnectApp
+
+### Motivation
+
+Bei einem regulären Beenden der Fachapplikation oder des Web GIS Clients soll die Session sofort aufgeräumt werden, ohne dass der Server auf den Ablauf der Reconnect-Grace-Period warten muss. Ohne diese Nachricht wartet der Server nach jedem Verbindungsabbruch — auch bei gewollten — auf einen möglichen Reconnect.
+
+### Aufbau der Nachricht
+
+```json
+{
+    "method": "disconnectGis|disconnectApp"
+}
+```
+
+### Verhalten des Servers
+
+Die `disconnect`-Nachricht wird nur von V1.2-Verbindungen akzeptiert. V1.0-Verbindungen werden beim Schliessen ohnehin sofort terminiert und benötigen diese Nachricht nicht. Sendet ein V1.0-Client eine `disconnect`-Nachricht, wird sie mit einem Fehler abgelehnt.
+
+Nach Empfang einer `disconnect`-Nachricht von einem V1.2-Client:
+1. Beide Verbindungen (App und GIS) werden mit Close-Code `1000 NORMAL` und Reason `"Client disconnected"` geschlossen.
+2. Die Session wird sofort aus der Session-Verwaltung entfernt.
+3. Ein Reconnect auf diese Session ist danach nicht mehr möglich.
+
+### Empfohlene Client-Implementierung
+
+Der Client sendet die `disconnect`-Nachricht über die bestehende WebSocket-Verbindung, bevor er die Verbindung schliesst:
+
+1. Client sendet `{"method": "disconnectApp"}` bzw. `{"method": "disconnectGis"}`
+2. Server schliesst beide Verbindungen
+3. Client schliesst WebSocket (falls noch offen)
 
 ## keyChange
 

--- a/src/main/java/ch/so/agi/cccservice/CCCWebSocketHandler.java
+++ b/src/main/java/ch/so/agi/cccservice/CCCWebSocketHandler.java
@@ -107,7 +107,7 @@ public class CCCWebSocketHandler extends TextWebSocketHandler {
         // Check connection limits before accepting
         if (!limiter.isConnectionAllowed(clientIp)) {
             log.warn("Connection from {} rejected due to connection limit", clientIp);
-            session.close(CloseStatus.POLICY_VIOLATION);
+            session.close(CloseStatus.SERVICE_OVERLOAD);
             return;
         }
 

--- a/src/main/java/ch/so/agi/cccservice/deamon/KeyChanger.java
+++ b/src/main/java/ch/so/agi/cccservice/deamon/KeyChanger.java
@@ -33,21 +33,28 @@ public class KeyChanger {
         List<Session> v12Sessions = Sessions.allSessions()
                 .filter(Session::hasV12Connection).toList();
 
+        List<Session> sentSessions = new java.util.ArrayList<>();
+
         for(Session ses : v12Sessions){
+            boolean sent = false;
             for(SockConnection con : ses.v12Connections()){
-                if(con.isOpen())
+                if(con.isOpen()) {
                     KeyChange.sendKeyChangeToConnection(con);
+                    sent = true;
+                }
             }
+            if(sent)
+                sentSessions.add(ses);
         }
 
-        String v12SessionsString = v12Sessions.stream()
+        String sentSessionsString = sentSessions.stream()
                 .map(ses -> Integer.toString(ses.getSessionNr()))
-                .collect(Collectors.joining(", "));;
+                .collect(Collectors.joining(", "));
 
         log.info(
                 "Sent keychange to the v 1.2 connections of {} sessions. Session numbers: [{}].",
-                v12Sessions.size(),
-                v12SessionsString
+                sentSessions.size(),
+                sentSessionsString
         );
     }
 }

--- a/src/main/java/ch/so/agi/cccservice/health/SocketClient.java
+++ b/src/main/java/ch/so/agi/cccservice/health/SocketClient.java
@@ -23,6 +23,8 @@ import ch.so.agi.cccservice.message.ErrorMessage;
 import ch.so.agi.cccservice.message.KeyChange;
 import ch.so.agi.cccservice.message.SessionReady;
 import ch.so.agi.cccservice.message.app.ChangeLayerVisibility;
+import ch.so.agi.cccservice.message.app.DisconnectApp;
+import ch.so.agi.cccservice.message.gis.DisconnectGis;
 import ch.so.agi.cccservice.message.gis.GeoObjectSelected;
 
 /**
@@ -146,6 +148,20 @@ public class SocketClient extends TextWebSocketHandler {
             json.put("layerIdentifier", "fuu");
             json.put("visible", false);
         }
+
+        sendPayload(sockSession, json);
+    }
+
+    public synchronized void disconnectCCC() {
+        awaitSessionReady();
+        assertSocketOpen();
+
+        String method = (clientType == ClientType.APP)
+                ? DisconnectApp.MESSAGE_TYPE
+                : DisconnectGis.MESSAGE_TYPE;
+
+        ObjectNode json = OBJECT_MAPPER.createObjectNode();
+        json.put("method", method);
 
         sendPayload(sockSession, json);
     }

--- a/src/main/java/ch/so/agi/cccservice/message/Disconnect.java
+++ b/src/main/java/ch/so/agi/cccservice/message/Disconnect.java
@@ -1,0 +1,43 @@
+package ch.so.agi.cccservice.message;
+
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import ch.so.agi.cccservice.session.Session;
+import ch.so.agi.cccservice.session.Sessions;
+
+/**
+ * Message sent from app or gis to signal an intentional, final disconnection.
+ * Upon receiving this message, the server closes both connections immediately
+ * and removes the session — no reconnect grace period is applied.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class Disconnect extends Message {
+
+    public Disconnect(String messageType) {
+        super(messageType);
+    }
+
+    /**
+     * Type of the disconnecting client (app or gis). To be implemented in subclasses.
+     */
+    protected abstract String clientType();
+
+    @Override
+    public void process(WebSocketSession sourceConnection) {
+        Session s = Sessions.findByConnection(sourceConnection);
+        if (s == null) {
+            log.warn("Ignoring {} from unknown connection", getMessageType());
+            return;
+        }
+
+        if (s.tryInitiateTermination()) {
+            log.info("Session {}: {} client sent disconnect — terminating session",
+                    s.getSessionNr(), clientType());
+            s.closeConnections(CloseStatus.NORMAL, "Client disconnected");
+            Sessions.removeSession(s);
+        }
+    }
+}

--- a/src/main/java/ch/so/agi/cccservice/message/Disconnect.java
+++ b/src/main/java/ch/so/agi/cccservice/message/Disconnect.java
@@ -5,13 +5,16 @@ import org.springframework.web.socket.WebSocketSession;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import ch.so.agi.cccservice.exception.MessageUnknownException;
 import ch.so.agi.cccservice.session.Session;
 import ch.so.agi.cccservice.session.Sessions;
 
 /**
- * Message sent from app or gis to signal an intentional, final disconnection.
+ * Message sent from a V1.2 app or gis client to signal an intentional, final disconnection.
  * Upon receiving this message, the server closes both connections immediately
  * and removes the session — no reconnect grace period is applied.
+ * Only valid for V1.2 connections; V1.0 connections are terminated immediately
+ * on close and do not need this message.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class Disconnect extends Message {
@@ -25,6 +28,8 @@ public abstract class Disconnect extends Message {
      */
     protected abstract String clientType();
 
+    protected abstract boolean isAppClient();
+
     @Override
     public void process(WebSocketSession sourceConnection) {
         Session s = Sessions.findByConnection(sourceConnection);
@@ -33,10 +38,14 @@ public abstract class Disconnect extends Message {
             return;
         }
 
+        if (!s.hasV12Connection()) {
+            throw new MessageUnknownException("Disconnect is only supported for V1.2 connections");
+        }
+
         if (s.tryInitiateTermination()) {
             log.info("Session {}: {} client sent disconnect — terminating session",
                     s.getSessionNr(), clientType());
-            s.closeConnections(CloseStatus.NORMAL, "Client disconnected");
+            s.closeConnections(CloseStatus.NORMAL, "Peer connection closed (V1.2)");
             Sessions.removeSession(s);
         }
     }

--- a/src/main/java/ch/so/agi/cccservice/message/Message.java
+++ b/src/main/java/ch/so/agi/cccservice/message/Message.java
@@ -22,9 +22,11 @@ import ch.so.agi.cccservice.message.app.ConnectApp;
 import ch.so.agi.cccservice.message.app.CreateGeoObject;
 import ch.so.agi.cccservice.message.app.EditGeoObject;
 import ch.so.agi.cccservice.message.app.ObjectUpdated;
+import ch.so.agi.cccservice.message.app.DisconnectApp;
 import ch.so.agi.cccservice.message.app.ReconnectApp;
 import ch.so.agi.cccservice.message.app.ShowGeoObject;
 import ch.so.agi.cccservice.message.gis.ConnectGis;
+import ch.so.agi.cccservice.message.gis.DisconnectGis;
 import ch.so.agi.cccservice.message.gis.EditGeoObjectDone;
 import ch.so.agi.cccservice.message.gis.GeoObjectSelected;
 import ch.so.agi.cccservice.message.gis.ReconnectGis;
@@ -98,6 +100,8 @@ abstract public class Message {
         MESSAGE_TYPES.put(ObjectUpdated.MESSAGE_TYPE, ObjectUpdated.class);
         MESSAGE_TYPES.put(ReconnectGis.MESSAGE_TYPE, ReconnectGis.class);
         MESSAGE_TYPES.put(ReconnectApp.MESSAGE_TYPE, ReconnectApp.class);
+        MESSAGE_TYPES.put(DisconnectApp.MESSAGE_TYPE, DisconnectApp.class);
+        MESSAGE_TYPES.put(DisconnectGis.MESSAGE_TYPE, DisconnectGis.class);
     }
 
     /**

--- a/src/main/java/ch/so/agi/cccservice/message/app/DisconnectApp.java
+++ b/src/main/java/ch/so/agi/cccservice/message/app/DisconnectApp.java
@@ -1,0 +1,15 @@
+package ch.so.agi.cccservice.message.app;
+
+import ch.so.agi.cccservice.message.Disconnect;
+
+public class DisconnectApp extends Disconnect {
+    public static final String MESSAGE_TYPE = "disconnectApp";
+    DisconnectApp() {
+        super(MESSAGE_TYPE);
+    }
+
+    @Override
+    protected String clientType() {
+        return APP_CLIENT_TYPENAME;
+    }
+}

--- a/src/main/java/ch/so/agi/cccservice/message/app/DisconnectApp.java
+++ b/src/main/java/ch/so/agi/cccservice/message/app/DisconnectApp.java
@@ -12,4 +12,9 @@ public class DisconnectApp extends Disconnect {
     protected String clientType() {
         return APP_CLIENT_TYPENAME;
     }
+
+    @Override
+    protected boolean isAppClient() {
+        return true;
+    }
 }

--- a/src/main/java/ch/so/agi/cccservice/message/gis/DisconnectGis.java
+++ b/src/main/java/ch/so/agi/cccservice/message/gis/DisconnectGis.java
@@ -12,4 +12,9 @@ public class DisconnectGis extends Disconnect {
     protected String clientType() {
         return GIS_CLIENT_TYPENAME;
     }
+
+    @Override
+    protected boolean isAppClient() {
+        return false;
+    }
 }

--- a/src/main/java/ch/so/agi/cccservice/message/gis/DisconnectGis.java
+++ b/src/main/java/ch/so/agi/cccservice/message/gis/DisconnectGis.java
@@ -1,0 +1,15 @@
+package ch.so.agi.cccservice.message.gis;
+
+import ch.so.agi.cccservice.message.Disconnect;
+
+public class DisconnectGis extends Disconnect {
+    public static final String MESSAGE_TYPE = "disconnectGis";
+    DisconnectGis() {
+        super(MESSAGE_TYPE);
+    }
+
+    @Override
+    protected String clientType() {
+        return GIS_CLIENT_TYPENAME;
+    }
+}

--- a/src/main/java/ch/so/agi/cccservice/session/Sessions.java
+++ b/src/main/java/ch/so/agi/cccservice/session/Sessions.java
@@ -1,11 +1,14 @@
 package ch.so.agi.cccservice.session;
 
-import org.springframework.web.socket.WebSocketSession;
-
 import java.time.Duration;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
+
+import org.springframework.web.socket.WebSocketSession;
 
 public class Sessions {
     /**
@@ -151,12 +154,12 @@ public class Sessions {
         for(Session s : staleSessions){
             if (s.handShakeExceeded()) {
                 s.closeConnections(
-                    org.springframework.web.socket.CloseStatus.POLICY_VIOLATION,
+                    org.springframework.web.socket.CloseStatus.GOING_AWAY,
                     "Handshake timeout exceeded"
                 );
             } else {
                 s.closeConnections(
-                    org.springframework.web.socket.CloseStatus.GOING_AWAY,
+                    org.springframework.web.socket.CloseStatus.NORMAL,
                     "Reconnection timeout"
                 );
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ ccc.security.connection-limiter.enabled=false
 ccc.security.rate-limiter.enabled=false
 
 # Smoke Test
-# ccc.smoke.url=wss://defineWebsocketUrlHereIfNeeded
+# ccc.smoke.url=ws://localhost:8080/ccc-service
 
 # Kubernetes Probes (auch lokal aktivieren, damit Namenskonflikte früh auffallen)
 management.endpoint.health.probes.enabled=true

--- a/src/test/java/ch/so/agi/cccservice/deamon/KeyChangerTest.java
+++ b/src/test/java/ch/so/agi/cccservice/deamon/KeyChangerTest.java
@@ -72,4 +72,27 @@ class KeyChangerTest {
         lastMessage = ((MockWebSocketSession) v12Only.getGisWebSocket()).getLastSentTextMessage();
         assertTrue(lastMessage.contains(KEYCHANGE_METHOD));
     }
+
+    @Test
+    void sendKeyChangeSkipsClosedV12Connections() throws Exception {
+        Session session = TestUtil.initSession(UUID.randomUUID(), SockConnection.PROTOCOL_V12, SockConnection.PROTOCOL_V12);
+
+        MockWebSocketSession appSocket = (MockWebSocketSession) session.getAppWebSocket();
+        MockWebSocketSession gisSocket = (MockWebSocketSession) session.getGisWebSocket();
+
+        // Simulate GIS connection closed (e.g. browser reload)
+        gisSocket.close();
+
+        int appMessagesBefore = appSocket.getSentTextMessages().size();
+        int gisMessagesBefore = gisSocket.getSentTextMessages().size();
+
+        new KeyChanger().sendKeyChange();
+
+        // App connection is open — should receive keyChange
+        assertEquals(appMessagesBefore + 1, appSocket.getSentTextMessages().size());
+        assertTrue(appSocket.getLastSentTextMessage().contains(KEYCHANGE_METHOD));
+
+        // GIS connection is closed — should NOT receive keyChange
+        assertEquals(gisMessagesBefore, gisSocket.getSentTextMessages().size());
+    }
 }

--- a/src/test/java/ch/so/agi/cccservice/health/SmokeTest.java
+++ b/src/test/java/ch/so/agi/cccservice/health/SmokeTest.java
@@ -67,6 +67,48 @@ class SmokeTest {
         app.closeWebSocket();
     }
 
+    @Test
+    void connectAndDisconnect() throws InterruptedException {
+        String url = resolveUrl();
+
+        // 1. Both clients connect (new session)
+        SocketClient gis = new SocketClient(url, GIS);
+        SocketClient app = new SocketClient(url, APP);
+        UUID session = UUID.randomUUID();
+        gis.connectCCC(session, "smoke-gis", "1.2", GIS);
+        app.connectCCC(session, "smoke-app", "1.2", APP);
+
+        // 2. APP sends disconnect — server should close both connections
+        Thread.sleep(500);
+        app.disconnectCCC();
+
+        // 3. Verify both connections were closed by the server
+        Thread.sleep(500);
+        assert !app.webSocketIsOpen() : "App connection should be closed after disconnect";
+        assert !gis.webSocketIsOpen() : "Gis connection should be closed after disconnect";
+    }
+
+    @Test
+    void connectAndDisconnectFromGis() throws InterruptedException {
+        String url = resolveUrl();
+
+        // 1. Both clients connect (new session)
+        SocketClient gis = new SocketClient(url, GIS);
+        SocketClient app = new SocketClient(url, APP);
+        UUID session = UUID.randomUUID();
+        gis.connectCCC(session, "smoke-gis", "1.2", GIS);
+        app.connectCCC(session, "smoke-app", "1.2", APP);
+
+        // 2. GIS sends disconnect — server should close both connections
+        Thread.sleep(500);
+        gis.disconnectCCC();
+
+        // 3. Verify both connections were closed by the server
+        Thread.sleep(500);
+        assert !gis.webSocketIsOpen() : "Gis connection should be closed after disconnect";
+        assert !app.webSocketIsOpen() : "App connection should be closed after disconnect";
+    }
+
     private static String resolveUrl() {
         String sysProp = System.getProperty(PROPERTY_KEY);
         if (sysProp != null && !sysProp.isBlank()) {

--- a/src/test/java/ch/so/agi/cccservice/message/DisconnectTest.java
+++ b/src/test/java/ch/so/agi/cccservice/message/DisconnectTest.java
@@ -1,0 +1,101 @@
+package ch.so.agi.cccservice.message;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ch.so.agi.cccservice.MessageHandler;
+import ch.so.agi.cccservice.TestUtil;
+import ch.so.agi.cccservice.session.MockWebSocketSession;
+import ch.so.agi.cccservice.session.Session;
+import ch.so.agi.cccservice.session.Sessions;
+import ch.so.agi.cccservice.session.SockConnection;
+
+class DisconnectTest {
+
+    @BeforeEach
+    void reset() {
+        Sessions.resetSessionCollection();
+    }
+
+    @Test
+    void disconnectApp_removesSession() {
+        UUID sessionId = UUID.randomUUID();
+        Session s = TestUtil.initSession(sessionId, SockConnection.PROTOCOL_V12, SockConnection.PROTOCOL_V12);
+
+        MockWebSocketSession appSocket = (MockWebSocketSession) s.getAppWebSocket();
+        MessageHandler.handleMessage(appSocket, disconnectMessage("disconnectApp"));
+
+        assertNull(Sessions.findBySessionUid(sessionId), "Session should be removed after disconnect");
+    }
+
+    @Test
+    void disconnectGis_removesSession() {
+        UUID sessionId = UUID.randomUUID();
+        Session s = TestUtil.initSession(sessionId, SockConnection.PROTOCOL_V12, SockConnection.PROTOCOL_V12);
+
+        MockWebSocketSession gisSocket = (MockWebSocketSession) s.getGisWebSocket();
+        MessageHandler.handleMessage(gisSocket, disconnectMessage("disconnectGis"));
+
+        assertNull(Sessions.findBySessionUid(sessionId), "Session should be removed after disconnect");
+    }
+
+    @Test
+    void disconnectApp_closesBothConnections() {
+        UUID sessionId = UUID.randomUUID();
+        Session s = TestUtil.initSession(sessionId, SockConnection.PROTOCOL_V12, SockConnection.PROTOCOL_V12);
+
+        MockWebSocketSession appSocket = (MockWebSocketSession) s.getAppWebSocket();
+        MockWebSocketSession gisSocket = (MockWebSocketSession) s.getGisWebSocket();
+
+        MessageHandler.handleMessage(appSocket, disconnectMessage("disconnectApp"));
+
+        assertFalse(appSocket.isOpen(), "App connection should be closed");
+        assertFalse(gisSocket.isOpen(), "Gis connection should also be closed");
+    }
+
+    @Test
+    void disconnect_unknownConnection_isIgnored() {
+        MockWebSocketSession unknownSocket = new MockWebSocketSession();
+        // Should not throw
+        MessageHandler.handleMessage(unknownSocket, disconnectMessage("disconnectApp"));
+    }
+
+    @Test
+    void disconnect_v10Session_removesSession() {
+        UUID sessionId = UUID.randomUUID();
+        Session s = TestUtil.initSession(sessionId);
+
+        MockWebSocketSession appSocket = (MockWebSocketSession) s.getAppWebSocket();
+        MessageHandler.handleMessage(appSocket, disconnectMessage("disconnectApp"));
+
+        assertNull(Sessions.findBySessionUid(sessionId), "V1.0 session should also be removed after disconnect");
+    }
+
+    @Test
+    void disconnect_otherSessionsUnaffected() {
+        UUID sessionId1 = UUID.randomUUID();
+        UUID sessionId2 = UUID.randomUUID();
+        Session s1 = TestUtil.initSession(sessionId1, SockConnection.PROTOCOL_V12, SockConnection.PROTOCOL_V12);
+        Session s2 = TestUtil.initSession(sessionId2, SockConnection.PROTOCOL_V12, SockConnection.PROTOCOL_V12);
+
+        MockWebSocketSession appSocket1 = (MockWebSocketSession) s1.getAppWebSocket();
+        MessageHandler.handleMessage(appSocket1, disconnectMessage("disconnectApp"));
+
+        assertNull(Sessions.findBySessionUid(sessionId1), "Disconnected session should be removed");
+        assertTrue(s2.getAppWebSocket().isOpen(), "Other session's app connection should remain open");
+        assertTrue(s2.getGisWebSocket().isOpen(), "Other session's gis connection should remain open");
+    }
+
+    private String disconnectMessage(String method) {
+        return """
+                {
+                    "method": "%s"
+                }
+                """.formatted(method);
+    }
+}

--- a/src/test/java/ch/so/agi/cccservice/message/DisconnectTest.java
+++ b/src/test/java/ch/so/agi/cccservice/message/DisconnectTest.java
@@ -92,10 +92,6 @@ class DisconnectTest {
     }
 
     private String disconnectMessage(String method) {
-        return """
-                {
-                    "method": "%s"
-                }
-                """.formatted(method);
+        return "{\"method\": \"" + method + "\"}";
     }
 }

--- a/src/test/java/ch/so/agi/cccservice/message/DisconnectTest.java
+++ b/src/test/java/ch/so/agi/cccservice/message/DisconnectTest.java
@@ -3,6 +3,7 @@ package ch.so.agi.cccservice.message;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,14 +67,15 @@ class DisconnectTest {
     }
 
     @Test
-    void disconnect_v10Session_removesSession() {
+    void disconnect_v10Session_isRejected() {
         UUID sessionId = UUID.randomUUID();
         Session s = TestUtil.initSession(sessionId);
 
         MockWebSocketSession appSocket = (MockWebSocketSession) s.getAppWebSocket();
         MessageHandler.handleMessage(appSocket, disconnectMessage("disconnectApp"));
 
-        assertNull(Sessions.findBySessionUid(sessionId), "V1.0 session should also be removed after disconnect");
+        assertNotNull(Sessions.findBySessionUid(sessionId), "V1.0 session should not be removed by disconnect");
+        assertTrue(appSocket.isOpen(), "V1.0 connection should remain open");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add `disconnectApp` / `disconnectGis` message types so V1.2 clients can signal an intentional session close. The server terminates the session immediately without waiting for the reconnect grace period.
- V1.0 clients are rejected with an error since they don't support reconnect and are already terminated on close.
- Protocol documentation updated in `docs/protocol/v1.2.md`.

## Motivation

V1.2 connections support reconnect, so every closed connection triggers a grace period where the server waits for a potential reconnect. When a client closes intentionally (e.g. user ends the session), this wait is unnecessary. The new `disconnect` message lets clients explicitly signal "no reconnect expected", allowing the server to clean up immediately.

## Test plan

- [x] `disconnectApp` removes session and closes both connections
- [x] `disconnectGis` removes session and closes both connections
- [x] V1.0 session rejects disconnect (session remains intact)
- [x] Unknown connection is silently ignored
- [x] Other sessions are unaffected
- [x] All existing tests pass
- [x] SpotBugs clean