### PR TITLE
Remove global lock from ErrorSender

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ tasks.named('test') {
     useJUnitPlatform {
         excludeTags 'integration', 'smoke'
     }
+    testLogging {
+        events 'failed'
+        exceptionFormat 'full'
+    }
 }
 
 tasks.register('integrationTest', Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,15 @@ tasks.named('bootJar') {
 // Remove once Spring Boot ships with Tomcat >= 10.1.55.
 ext['tomcat.version'] = '10.1.55'
 
+// Override Jackson to 2.21.4 for CVE-2026-54513 (jackson-databind RCE, 8.1):
+// BasicPolymorphicTypeValidator.allowIfSubTypeIsArray() didn't validate the
+// array's element type, letting a disallowed "gadget" class slip through
+// polymorphic deserialization. This app doesn't use Jackson's polymorphic typing
+// (no PolymorphicTypeValidator/@JsonTypeInfo/activateDefaultTyping), so the
+// vulnerable path isn't reachable today, but pin the fixed version anyway.
+// Remove once Spring Boot ships with jackson-bom >= 2.21.4.
+ext['jackson-bom.version'] = '2.21.4'
+
 repositories {
     mavenCentral()
 }
@@ -110,6 +119,7 @@ tasks.register('buildImage', Exec) {
 
     commandLine 'docker', 'build',
             '--no-cache',
+            '--pull',
             '-t', "sogis/ccc-service:latest",
             '-t', "sogis/ccc-service:$buildident",
             '--label', "ccc-service.created=$build_timestamp",

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -16,6 +16,13 @@
         <Bug pattern="MS_EXPOSE_REP"/>
     </Match>
 
+    <!-- Test mock: storing the exception injected via failSendsWith() is the
+         hook's whole purpose; a defensive copy of a RuntimeException makes no sense -->
+    <Match>
+        <Class name="ch.so.agi.cccservice.session.MockWebSocketSession"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+
     <!-- SessionReady.method is read by Jackson via reflection -->
     <Match>
         <Class name="ch.so.agi.cccservice.message.SessionReady"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@
 
 org.gradle.configuration-cache=true
 
-cccVersion=1.2.5
+cccVersion=1.2.6

--- a/src/main/java/ch/so/agi/cccservice/CCCWebSocketHandler.java
+++ b/src/main/java/ch/so/agi/cccservice/CCCWebSocketHandler.java
@@ -23,12 +23,25 @@ public class CCCWebSocketHandler extends TextWebSocketHandler {
     // values down to ~1s actually behave as configured.
     public static final int DEFAULT_CONNECT_MSG_MAX_DELAY_SECONDS = 2;
 
+    // Tomcat's own default (Constants.DEFAULT_BLOCKING_SEND_TIMEOUT) is 20s; we use a
+    // shorter default so an unresponsive peer ties up a worker thread for less time.
+    public static final int DEFAULT_SEND_TIMEOUT_SECONDS = 5;
+
+    // Recognized by Tomcat's WsRemoteEndpointImplBase as a per-session override for the
+    // blocking-send timeout (org.apache.tomcat.websocket.Constants.BLOCKING_SEND_TIMEOUT_PROPERTY).
+    // Not part of the Jakarta WebSocket standard API, so referenced by literal key rather
+    // than importing the Tomcat-internal class - see TomcatWebSocketTuning for the same
+    // Tomcat-coupling trade-off.
+    private static final String BLOCKING_SEND_TIMEOUT_PROPERTY =
+        "org.apache.tomcat.websocket.BLOCKING_SEND_TIMEOUT";
+
     private static final Logger log = LoggerFactory.getLogger(
         CCCWebSocketHandler.class
     );
 
     private final MessageAccumulator accumulator;
     private final int connectMsgMaxDelaySeconds;
+    private final int sendTimeoutSeconds;
 
     public CCCWebSocketHandler(
         MessageAccumulator accumulator,
@@ -37,6 +50,11 @@ public class CCCWebSocketHandler extends TextWebSocketHandler {
                 DEFAULT_CONNECT_MSG_MAX_DELAY_SECONDS +
                 "}"
         ) int connectMsgMaxDelaySeconds,
+        @Value(
+            "${ccc.websocket.send-timeout-seconds:" +
+                DEFAULT_SEND_TIMEOUT_SECONDS +
+                "}"
+        ) int sendTimeoutSeconds,
         @Value(
             "${ccc.security.connection-limiter.enabled:false}"
         ) boolean connectionLimiterEnabled,
@@ -47,6 +65,7 @@ public class CCCWebSocketHandler extends TextWebSocketHandler {
     ) {
         this.accumulator = accumulator;
         this.connectMsgMaxDelaySeconds = connectMsgMaxDelaySeconds;
+        this.sendTimeoutSeconds = sendTimeoutSeconds;
 
         ConnectionLimiter.getInstance().setEnabled(connectionLimiterEnabled);
         ConnectionRateLimiter.getConnectLimiter().setEnabled(
@@ -154,6 +173,11 @@ public class CCCWebSocketHandler extends TextWebSocketHandler {
         // is scheduled per incoming connection, so a connection storm cannot
         // starve commonPool or fill an unbounded DelayQueue.
         setIdleTimeout(session, connectMsgMaxDelaySeconds * 1000L);
+
+        // Bound how long a blocking sendMessage()/sendPing() call may wait on this
+        // connection (e.g. a peer that stopped reading). Applies for the connection's
+        // whole lifetime, unlike the idle timeout above which is lifted after Connect.
+        setSendTimeout(session, sendTimeoutSeconds * 1000L);
     }
 
     /**
@@ -171,6 +195,27 @@ public class CCCWebSocketHandler extends TextWebSocketHandler {
             jakarta.websocket.Session nativeSession = sws.getNativeSession();
             if (nativeSession != null) {
                 nativeSession.setMaxIdleTimeout(millis);
+            }
+        }
+    }
+
+    /**
+     * Bounds how long a blocking send (sendMessage/sendPing, via getBasicRemote()) may wait
+     * on this connection before Tomcat aborts it with a SocketTimeoutException and closes the
+     * session. Without this, Tomcat's own default of 20s (Constants.DEFAULT_BLOCKING_SEND_TIMEOUT)
+     * applies - long enough that an unresponsive peer can tie up a worker thread for a
+     * meaningful window. Set once; unlike the idle timeout, this is not lifted after Connect.
+     *
+     * @param session WebSocket session
+     * @param millis  send timeout in ms
+     */
+    public static void setSendTimeout(WebSocketSession session, long millis) {
+        if (session instanceof StandardWebSocketSession sws) {
+            jakarta.websocket.Session nativeSession = sws.getNativeSession();
+            if (nativeSession != null) {
+                nativeSession
+                    .getUserProperties()
+                    .put(BLOCKING_SEND_TIMEOUT_PROPERTY, millis);
             }
         }
     }

--- a/src/main/java/ch/so/agi/cccservice/message/ErrorSender.java
+++ b/src/main/java/ch/so/agi/cccservice/message/ErrorSender.java
@@ -23,7 +23,12 @@ public final class ErrorSender {
     private ErrorSender() {
     }
 
-    public static synchronized void send(WebSocketSession connection, ClientException exception) {
+    // Deliberately unsynchronized: mapper.createObjectNode() creates a fresh instance per
+    // call, so there is no shared mutable state to protect. A lock here would serialize
+    // error delivery for ALL sessions on a single monitor, so one slow/unresponsive client
+    // blocking inside sendMessage() would stall error delivery for every unrelated session
+    // too (see ErrorSenderConcurrencyTest).
+    public static void send(WebSocketSession connection, ClientException exception) {
         if (connection == null) {
             return;
         }

--- a/src/main/java/ch/so/agi/cccservice/session/SockConnection.java
+++ b/src/main/java/ch/so/agi/cccservice/session/SockConnection.java
@@ -2,6 +2,8 @@ package ch.so.agi.cccservice.session;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.socket.PingMessage;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -11,6 +13,8 @@ import org.springframework.web.socket.WebSocketSession;
  * and either app or gis client.
  */
 public final class SockConnection {
+    private static final Logger log = LoggerFactory.getLogger(SockConnection.class);
+
     public static final String PROTOCOL_V1 = "1.0";
     public static final String PROTOCOL_V12 = "1.2";
 
@@ -85,9 +89,11 @@ public final class SockConnection {
         try {
             webSocketConnection.sendMessage(msg);
         } catch (IllegalStateException e) {
-            // Connection was closed between isOpen() check and sendMessage()
-            // This is a race condition that can happen during session termination
-            // Silently ignore - the message is lost but that's acceptable
+            // Connection was closed between isOpen() check and sendMessage(),
+            // or another thread wrote to the same connection concurrently
+            // (TEXT_FULL_WRITING). The message is lost either way; log it so
+            // the loss is at least diagnosable.
+            log.debug("Message to client {} lost: {}", clientName, e.toString());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -104,7 +110,9 @@ public final class SockConnection {
         try {
             webSocketConnection.sendMessage(ping);
         } catch (IllegalStateException e) {
-            // Connection was closed between isOpen() check and sendMessage()
+            // Connection was closed between isOpen() check and sendMessage(),
+            // or another thread wrote to the same connection concurrently.
+            log.debug("Ping to client {} lost: {}", clientName, e.toString());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,12 @@ ccc.websocket.max-binary-message-buffer-size=8192
 # short pre-Connect timeouts behave as configured.
 ccc.websocket.idle-check-period-seconds=1
 
+# Maximum seconds a single blocking sendMessage()/sendPing() call may wait on an
+# unresponsive peer before Tomcat aborts it and closes the session. Tomcat's own
+# default is 20s (Constants.DEFAULT_BLOCKING_SEND_TIMEOUT); lowering it here bounds
+# how long one slow/unresponsive client can tie up a worker thread.
+ccc.websocket.send-timeout-seconds=5
+
 # Message Accumulator Configuration
 ccc.accumulator.timeout-seconds=30
 ccc.accumulator.max-size=1048576

--- a/src/test/java/ch/so/agi/cccservice/CCCWebSocketHandlerTest.java
+++ b/src/test/java/ch/so/agi/cccservice/CCCWebSocketHandlerTest.java
@@ -25,7 +25,7 @@ class CCCWebSocketHandlerTest {
     @BeforeEach
     void setUp() {
         Sessions.resetSessionCollection();
-        handler = new CCCWebSocketHandler(new MessageAccumulator(), CCCWebSocketHandler.DEFAULT_CONNECT_MSG_MAX_DELAY_SECONDS, true, true, 0);
+        handler = new CCCWebSocketHandler(new MessageAccumulator(), CCCWebSocketHandler.DEFAULT_CONNECT_MSG_MAX_DELAY_SECONDS, CCCWebSocketHandler.DEFAULT_SEND_TIMEOUT_SECONDS, true, true, 0);
     }
 
     // The pre-Connect timeout is now enforced by Tomcat's native idle-timeout on

--- a/src/test/java/ch/so/agi/cccservice/SendTimeoutConfigurationTest.java
+++ b/src/test/java/ch/so/agi/cccservice/SendTimeoutConfigurationTest.java
@@ -1,0 +1,82 @@
+package ch.so.agi.cccservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.socket.adapter.standard.StandardWebSocketSession;
+
+import ch.so.agi.cccservice.health.SocketClient;
+import ch.so.agi.cccservice.health.WebServerPort;
+import ch.so.agi.cccservice.session.Session;
+import ch.so.agi.cccservice.session.SockConnection;
+import ch.so.agi.cccservice.session.Sessions;
+
+/**
+ * Verifies that ccc.websocket.send-timeout-seconds is actually applied to real WebSocket
+ * connections as Tomcat's per-session blocking-send-timeout override, catching
+ * property-name/unit typos that Spring would otherwise silently ignore (same rationale as
+ * TomcatLimitsConfigurationTest, applied here to CCCWebSocketHandler#setSendTimeout instead
+ * of server.tomcat.* properties).
+ *
+ * The actual timeout behaviour (an unresponsive peer gets aborted after roughly this many
+ * seconds instead of Tomcat's own 20s default) was verified manually by running the app with
+ * ccc.websocket.send-timeout-seconds=2 and a raw socket GIS peer that stops reading after the
+ * handshake: the server aborted the stalled write after 2.03s with
+ * CloseStatus[code=1006, reason="Write timeout"]. That scenario needs an unbounded, slow
+ * real socket and isn't suitable for the regular test suite, so only the fast, deterministic
+ * wiring check below is automated.
+ */
+@Tag("integration")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SendTimeoutConfigurationTest {
+
+    private static final String BLOCKING_SEND_TIMEOUT_PROPERTY =
+            "org.apache.tomcat.websocket.BLOCKING_SEND_TIMEOUT";
+
+    @Value("${ccc.websocket.send-timeout-seconds:" + CCCWebSocketHandler.DEFAULT_SEND_TIMEOUT_SECONDS + "}")
+    private int expectedSendTimeoutSeconds;
+
+    @Test
+    void establishedConnection_hasConfiguredBlockingSendTimeout() {
+        Sessions.resetSessionCollection();
+
+        String adr = "ws://localhost:" + WebServerPort.getPort() + WebSocketConfig.CCC_SOCKET_PATH;
+        UUID sessionUid = UUID.randomUUID();
+
+        SocketClient appClient = new SocketClient(adr, SocketClient.ClientType.APP);
+        SocketClient gisClient = new SocketClient(adr, SocketClient.ClientType.GIS);
+
+        appClient.connectCCC(sessionUid, "test-app", SockConnection.PROTOCOL_V12, SocketClient.ClientType.APP);
+        gisClient.connectCCC(sessionUid, "test-gis", SockConnection.PROTOCOL_V12, SocketClient.ClientType.GIS);
+
+        Awaitility.await().atMost(2, TimeUnit.SECONDS)
+                .until(() -> appClient.getSessionNr() != null && gisClient.getSessionNr() != null);
+
+        Session serverSession = Sessions.allSessions()
+                .filter(s -> s.getSessionNr() == appClient.getSessionNr())
+                .findFirst()
+                .orElseThrow();
+
+        long expectedMillis = expectedSendTimeoutSeconds * 1000L;
+        assertEquals(expectedMillis, blockingSendTimeoutOf(serverSession.getAppWebSocket()),
+                "App connection should have the configured blocking-send timeout");
+        assertEquals(expectedMillis, blockingSendTimeoutOf(serverSession.getGisWebSocket()),
+                "GIS connection should have the configured blocking-send timeout");
+    }
+
+    private Object blockingSendTimeoutOf(org.springframework.web.socket.WebSocketSession session) {
+        assertNotNull(session);
+        StandardWebSocketSession sws = (StandardWebSocketSession) session;
+        jakarta.websocket.Session nativeSession = sws.getNativeSession();
+        assertNotNull(nativeSession);
+        return nativeSession.getUserProperties().get(BLOCKING_SEND_TIMEOUT_PROPERTY);
+    }
+}

--- a/src/test/java/ch/so/agi/cccservice/message/ErrorSenderConcurrencyTest.java
+++ b/src/test/java/ch/so/agi/cccservice/message/ErrorSenderConcurrencyTest.java
@@ -1,0 +1,137 @@
+package ch.so.agi.cccservice.message;
+
+import ch.so.agi.cccservice.exception.MessageMalformedException;
+import ch.so.agi.cccservice.session.MockWebSocketSession;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketExtension;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.Principal;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards against ErrorSender.send() serializing error delivery across unrelated sessions.
+ * As long as it is declared static synchronized, it holds a JVM-wide lock; combined with
+ * WebSocketSession.sendMessage() being a blocking call with no configured send timeout
+ * anywhere in this project, a single slow/unresponsive client can stall error delivery for
+ * every OTHER, completely unrelated session while the lock is held.
+ *
+ * This test simulates that: one "attacker" session blocks inside sendMessage() (standing in
+ * for a real socket whose peer never reads, so the TCP write blocks), while a second,
+ * healthy "victim" session tries to receive an unrelated error message concurrently. The test
+ * fails as long as the attacker can delay the victim.
+ */
+class ErrorSenderConcurrencyTest {
+
+    private static final long SLOW_SEND_MILLIS = 1500;
+    private static final long MAX_ACCEPTABLE_VICTIM_DELAY_MILLIS = 500;
+
+    /** Wraps a MockWebSocketSession but blocks in sendMessage() to simulate an unresponsive peer. */
+    private static class SlowWebSocketSession implements WebSocketSession {
+        private final MockWebSocketSession delegate = MockWebSocketSession.create();
+        private final CountDownLatch entered = new CountDownLatch(1);
+
+        CountDownLatch enteredLatch() { return entered; }
+
+        @Override
+        public void sendMessage(WebSocketMessage<?> message) throws IOException {
+            entered.countDown();
+            try {
+                // Simulates a blocking socket write to a client that never reads
+                // (e.g. TCP receive window full). No send-timeout is configured
+                // anywhere in this project (verified: no async-send-timeout /
+                // BLOCKING_SEND_TIMEOUT_PROPERTY set), so in production this could
+                // block indefinitely instead of a fixed 1.5s.
+                Thread.sleep(SLOW_SEND_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            delegate.sendMessage(message);
+        }
+
+        @Override public String getId() { return delegate.getId(); }
+        @Override public URI getUri() { return delegate.getUri(); }
+        @Override public HttpHeaders getHandshakeHeaders() { return delegate.getHandshakeHeaders(); }
+        @Override public Map<String, Object> getAttributes() { return delegate.getAttributes(); }
+        @Override public Principal getPrincipal() { return delegate.getPrincipal(); }
+        @Override public InetSocketAddress getLocalAddress() { return delegate.getLocalAddress(); }
+        @Override public InetSocketAddress getRemoteAddress() { return delegate.getRemoteAddress(); }
+        @Override public String getAcceptedProtocol() { return delegate.getAcceptedProtocol(); }
+        @Override public void setTextMessageSizeLimit(int limit) { delegate.setTextMessageSizeLimit(limit); }
+        @Override public int getTextMessageSizeLimit() { return delegate.getTextMessageSizeLimit(); }
+        @Override public void setBinaryMessageSizeLimit(int limit) { delegate.setBinaryMessageSizeLimit(limit); }
+        @Override public int getBinaryMessageSizeLimit() { return delegate.getBinaryMessageSizeLimit(); }
+        @Override public List<WebSocketExtension> getExtensions() { return delegate.getExtensions(); }
+        @Override public boolean isOpen() { return delegate.isOpen(); }
+        @Override public void close() throws IOException { delegate.close(); }
+        @Override public void close(CloseStatus status) throws IOException { delegate.close(status); }
+    }
+
+    @Test
+    void slowClientMustNotBlockErrorDeliveryToUnrelatedSession() throws Exception {
+        SlowWebSocketSession attackerSession = new SlowWebSocketSession();
+        MockWebSocketSession victimSession = MockWebSocketSession.create();
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            // "Attacker" thread: triggers a ClientException; sendMessage() blocks for
+            // SLOW_SEND_MILLIS *while holding ErrorSender's static (class-wide) lock*.
+            Future<?> attackerCall = pool.submit(() ->
+                    ErrorSender.send(attackerSession, new MessageMalformedException("malformed"))
+            );
+
+            // Make sure the attacker call is actually inside sendMessage() (i.e. holding
+            // the lock) before starting the victim call, to avoid a race in the assertion.
+            assertTrue(attackerSession.enteredLatch().await(2, TimeUnit.SECONDS),
+                    "Test setup failed: the attacker's ErrorSender.send() call never entered "
+                            + "sendMessage() within 2s, so the lock-holding scenario this test "
+                            + "relies on was never established. This points to a test/thread-pool "
+                            + "problem, not the vulnerability itself.");
+
+            // "Victim" thread: a completely unrelated, healthy session that also needs
+            // an (unrelated) error delivered concurrently.
+            long start = System.nanoTime();
+            Future<?> victimCall = pool.submit(() ->
+                    ErrorSender.send(victimSession, new MessageMalformedException("unrelated error"))
+            );
+            victimCall.get(5, TimeUnit.SECONDS);
+            long elapsedMillis = Duration.ofNanos(System.nanoTime() - start).toMillis();
+
+            attackerCall.get(5, TimeUnit.SECONDS);
+
+            // Regression assertion: the victim's error delivery must not be delayed by an
+            // unrelated slow client. If ErrorSender.send() keeps its static (JVM-wide)
+            // `synchronized`, the victim call queues up behind the attacker's held lock and
+            // this fails with an elapsed time close to SLOW_SEND_MILLIS.
+            assertTrue(elapsedMillis < MAX_ACCEPTABLE_VICTIM_DELAY_MILLIS, String.format(
+                    "ErrorSender.send() blocked an unrelated victim session for %dms "
+                            + "(allowed: < %dms). Cause: ErrorSender.send() is 'static "
+                            + "synchronized', i.e. a single JVM-wide lock shared by all "
+                            + "sessions; the attacker's call held that lock for the whole "
+                            + "duration of its blocking sendMessage() (%dms). Impact: one "
+                            + "slow/unresponsive client can stall error delivery for every "
+                            + "other, unrelated session and, with enough such connections, "
+                            + "exhaust the whole Tomcat worker pool (threads.max=50). "
+                            + "Fix: drop or scope the lock per-connection (see SockConnection) "
+                            + "and/or add a send timeout.",
+                    elapsedMillis, MAX_ACCEPTABLE_VICTIM_DELAY_MILLIS, SLOW_SEND_MILLIS));
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/ch/so/agi/cccservice/session/MockWebSocketSession.java
+++ b/src/test/java/ch/so/agi/cccservice/session/MockWebSocketSession.java
@@ -23,6 +23,7 @@ public final class MockWebSocketSession implements WebSocketSession {
     private final List<String> sentTextMessages = new ArrayList<>();
     private boolean open = true;
     private CloseStatus lastCloseStatus;
+    private RuntimeException sendFailure;
 
     public CloseStatus getLastCloseStatus() {
         return lastCloseStatus;
@@ -102,8 +103,20 @@ public final class MockWebSocketSession implements WebSocketSession {
         return Collections.emptyList();
     }
 
+    /**
+     * Lets every subsequent sendMessage() call throw the given exception, e.g. the
+     * IllegalStateException Tomcat throws on a concurrent write (TEXT_FULL_WRITING)
+     * or when the connection was closed between isOpen() check and send.
+     */
+    public void failSendsWith(RuntimeException e) {
+        this.sendFailure = e;
+    }
+
     @Override
     public void sendMessage(WebSocketMessage<?> message) throws IOException {
+        if (sendFailure != null) {
+            throw sendFailure;
+        }
         if (message instanceof TextMessage textMessage) {
             sentTextMessages.add(textMessage.getPayload());
         }

--- a/src/test/java/ch/so/agi/cccservice/session/SockConnectionTest.java
+++ b/src/test/java/ch/so/agi/cccservice/session/SockConnectionTest.java
@@ -3,10 +3,44 @@ package ch.so.agi.cccservice.session;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
+import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 
 class SockConnectionTest {
+
+    private final Logger sockConnectionLogger = (Logger) LoggerFactory.getLogger(SockConnection.class);
+    private ListAppender<ILoggingEvent> logAppender;
+    private Level previousLogLevel;
+
+    /**
+     * Captures log output of SockConnection at DEBUG level. Detached again in
+     * {@link #detachLogAppender()} so the level tweak does not leak into other tests.
+     */
+    private List<ILoggingEvent> captureSockConnectionLogs() {
+        previousLogLevel = sockConnectionLogger.getLevel();
+        sockConnectionLogger.setLevel(Level.DEBUG);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        sockConnectionLogger.addAppender(logAppender);
+        return logAppender.list;
+    }
+
+    @AfterEach
+    void detachLogAppender() {
+        if (logAppender != null) {
+            sockConnectionLogger.detachAppender(logAppender);
+            sockConnectionLogger.setLevel(previousLogLevel);
+            logAppender = null;
+        }
+    }
 
     // --- Protokoll-Validierung ---
 
@@ -46,6 +80,44 @@ class SockConnectionTest {
         con.sendMessage("hello");
 
         assertEquals("hello", socket.getLastSentTextMessage());
+    }
+
+    // --- IllegalStateException beim Senden: schlucken, aber auf DEBUG loggen ---
+
+    @Test
+    void sendMessage_illegalStateException_isSwallowedAndLoggedAtDebug() {
+        MockWebSocketSession socket = new MockWebSocketSession();
+        socket.failSendsWith(new IllegalStateException("The remote endpoint was in state [TEXT_FULL_WRITING]"));
+        SockConnection con = new SockConnection("testClient", SockConnection.PROTOCOL_V1, socket);
+        List<ILoggingEvent> logs = captureSockConnectionLogs();
+
+        assertDoesNotThrow(() -> con.sendMessage("hello"));
+
+        assertEquals(1, logs.size(), "Expected exactly one log event for the lost message");
+        ILoggingEvent event = logs.get(0);
+        assertEquals(Level.DEBUG, event.getLevel());
+        assertTrue(event.getFormattedMessage().contains("testClient"),
+                "Log should name the client: " + event.getFormattedMessage());
+        assertTrue(event.getFormattedMessage().contains("TEXT_FULL_WRITING"),
+                "Log should contain the exception text: " + event.getFormattedMessage());
+    }
+
+    @Test
+    void sendPing_illegalStateException_isSwallowedAndLoggedAtDebug() {
+        MockWebSocketSession socket = new MockWebSocketSession();
+        socket.failSendsWith(new IllegalStateException("Connection closed"));
+        SockConnection con = new SockConnection("testClient", SockConnection.PROTOCOL_V1, socket);
+        List<ILoggingEvent> logs = captureSockConnectionLogs();
+
+        assertDoesNotThrow(con::sendPing);
+
+        assertEquals(1, logs.size(), "Expected exactly one log event for the lost ping");
+        ILoggingEvent event = logs.get(0);
+        assertEquals(Level.DEBUG, event.getLevel());
+        assertTrue(event.getFormattedMessage().contains("testClient"),
+                "Log should name the client: " + event.getFormattedMessage());
+        assertTrue(event.getFormattedMessage().contains("Connection closed"),
+                "Log should contain the exception text: " + event.getFormattedMessage());
     }
 
     // --- isOpen ---


### PR DESCRIPTION
ErrorSender.send() no longer synchronizes because ObjectMapper node creation is per-call and thread-safe. The previous lock blocked all sessions when a single client stalled inside sendMessage().

Also enable full failure logging in the test task and bump version to 1.2.6.